### PR TITLE
Fix compilation error with libcurl < 7.69.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.ko
 *.obj
 *.elf
+*.bc
 
 # Linker output
 *.ilk

--- a/orafce_mail.c
+++ b/orafce_mail.c
@@ -490,7 +490,9 @@ orafce_send_mail(char *sender,
 			if (strncmp(orafce_smtp_url, "smtps://", 8) == 0)
 				(void) curl_easy_setopt(curl, CURLOPT_USE_SSL, CURLUSESSL_ALL);
 
+#if LIBCURL_VERSION_NUM >= 0x074500 /* 7.69.0 */
 			(void) curl_easy_setopt(curl, CURLOPT_MAIL_RCPT_ALLLOWFAILS, 1L);
+#endif
 
 			OOM_CHECK(curl_easy_setopt(curl, CURLOPT_MAIL_FROM, sender));
 


### PR DESCRIPTION
Error returned was:
```
orafce_mail.c:494:35: error: use of undeclared identifier 'CURLOPT_MAIL_RCPT_ALLLOWFAILS'
                                (void) curl_easy_setopt(curl, CURLOPT_MAIL_RCPT_ALLLOWFAILS, 1L);
```